### PR TITLE
Show prompt processing status

### DIFF
--- a/tui/server.go
+++ b/tui/server.go
@@ -227,9 +227,9 @@ func (s ServerModel) computeVPH() int {
 	}
 	n := len(s.tpsHistory)
 	hasTPS := n > 0 || s.liveTPS > 0 || s.livePrefillTPS > 0
-	if hasTPS {
+	if hasTPS || s.promptProgress > 0 {
 		lines++ // divider
-		if s.liveTPS > 0 || n > 0 {
+		if s.liveTPS > 0 || n > 0 || s.promptProgress > 0 {
 			lines++ // gen line
 		}
 		if s.livePrefillTPS > 0 || s.liveTotalGen > 0 || s.liveTotalPrompt > 0 {
@@ -372,7 +372,7 @@ func (s ServerModel) View() string {
 	_, p50, p95, n := computeTPSStats(s.tpsHistory)
 	hasTPS := n > 0 || s.liveTPS > 0 || s.livePrefillTPS > 0
 
-	if hasTPS {
+	if hasTPS || s.promptProgress > 0 {
 		divider := dim.Render("  " + strings.Repeat("─", max(s.width-6, 20)))
 		throughputLines = append(throughputLines, divider)
 

--- a/tui/server.go
+++ b/tui/server.go
@@ -366,9 +366,6 @@ func (s ServerModel) View() string {
 	if s.modelUsage != "" {
 		resourceLines = append(resourceLines, dim.Render("  proc    ")+splitMetricParts(s.modelUsage, val, dot))
 	}
-	if s.promptProgress > 0 {
-		resourceLines = append(resourceLines, dim.Render("  prompt  ")+hi.Render(fmt.Sprintf("%d%%", s.promptProgress)))
-	}
 
 	// ── throughput section (divider + gen + prefill) ───────────────────────
 	var throughputLines []string
@@ -391,6 +388,9 @@ func (s ServerModel) View() string {
 		}
 		if s.liveActive > 0 {
 			genSegs = append(genSegs, lipgloss.NewStyle().Foreground(t.Success).Render(fmt.Sprintf("● %d active", s.liveActive)))
+		}
+		if s.promptProgress > 0 {
+			genSegs = append(genSegs, hi.Render(fmt.Sprintf("%d%% prompt", s.promptProgress)))
 		}
 		if s.liveDeferred > 0 {
 			genSegs = append(genSegs, dim.Render(fmt.Sprintf("%d queued", s.liveDeferred)))

--- a/tui/server.go
+++ b/tui/server.go
@@ -18,7 +18,10 @@ import (
 
 const stopGraceTimeout = 5 * time.Second
 
-var ansiEscape = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+var (
+	ansiEscape    = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+	promptProgress = regexp.MustCompile(`prompt processing progress,.*progress = ([0-9.]+)`)
+)
 
 func stripAnsi(s string) string {
 	return ansiEscape.ReplaceAllString(s, "")
@@ -58,6 +61,7 @@ type ServerModel struct {
 	port            int
 	systemUsage     string
 	modelUsage      string
+	promptProgress  int // 0 = none, 1–100 = active
 	startedAt       time.Time
 	stoppedAt       time.Time
 	stopped         bool
@@ -136,7 +140,26 @@ func NewServerModel(args []string, profileName, modelName, modelType string, con
 
 func (s ServerModel) HandleLogLine(line string) (ServerModel, tea.Cmd) {
 	s = s.appendLogLine(line)
+	s = s.updatePromptProgress(line)
 	return s, listenForLog(s.logCh, s.exitCh)
+}
+
+func (s ServerModel) updatePromptProgress(line string) ServerModel {
+	if strings.Contains(line, "prompt processing done") {
+		s.promptProgress = 100
+		return s
+	}
+	if !strings.Contains(line, "prompt processing progress") {
+		return s
+	}
+	matches := promptProgress.FindStringSubmatch(line)
+	if len(matches) < 2 {
+		return s
+	}
+	var progress float64
+	fmt.Sscanf(matches[1], "%f", &progress)
+	s.promptProgress = int(progress * 100)
+	return s
 }
 
 func (s ServerModel) appendLogLine(line string) ServerModel {
@@ -343,6 +366,9 @@ func (s ServerModel) View() string {
 	if s.modelUsage != "" {
 		resourceLines = append(resourceLines, dim.Render("  proc    ")+splitMetricParts(s.modelUsage, val, dot))
 	}
+	if s.promptProgress > 0 {
+		resourceLines = append(resourceLines, dim.Render("  prompt  ")+hi.Render(fmt.Sprintf("%d%%", s.promptProgress)))
+	}
 
 	// ── throughput section (divider + gen + prefill) ───────────────────────
 	var throughputLines []string
@@ -400,6 +426,7 @@ func (s ServerModel) View() string {
 	parts = append(parts, resourceLines...)
 	parts = append(parts, throughputLines...)
 	header := strings.Join(parts, "\n")
+}
 
 	// Log viewport
 	logView := s.vp.View()

--- a/tui/server.go
+++ b/tui/server.go
@@ -426,7 +426,6 @@ func (s ServerModel) View() string {
 	parts = append(parts, resourceLines...)
 	parts = append(parts, throughputLines...)
 	header := strings.Join(parts, "\n")
-}
 
 	// Log viewport
 	logView := s.vp.View()

--- a/tui/server.go
+++ b/tui/server.go
@@ -157,7 +157,9 @@ func (s ServerModel) updatePromptProgress(line string) ServerModel {
 		return s
 	}
 	var progress float64
-	fmt.Sscanf(matches[1], "%f", &progress)
+	if _, err := fmt.Sscanf(matches[1], "%f", &progress); err != nil {
+		return s
+	}
 	s.promptProgress = int(progress * 100)
 	return s
 }
@@ -226,8 +228,8 @@ func (s ServerModel) computeVPH() int {
 		lines++
 	}
 	n := len(s.tpsHistory)
-	hasTPS := n > 0 || s.liveTPS > 0 || s.livePrefillTPS > 0
-	if hasTPS || s.promptProgress > 0 {
+	hasTPS := n > 0 || s.liveTPS > 0 || s.livePrefillTPS > 0 || s.promptProgress > 0
+	if hasTPS {
 		lines++ // divider
 		if s.liveTPS > 0 || n > 0 || s.promptProgress > 0 {
 			lines++ // gen line
@@ -284,6 +286,10 @@ func (s ServerModel) Update(msg tea.Msg) (ServerModel, tea.Cmd) {
 			return s, nil
 		}
 		if msg.ok {
+			// Reset prompt progress once generation starts.
+			if s.liveActive > 0 {
+				s.promptProgress = 0
+			}
 			s.liveTPS = msg.avgTPS
 			s.livePrefillTPS = msg.prefillTPS
 			s.liveActive = msg.active
@@ -370,9 +376,9 @@ func (s ServerModel) View() string {
 	// ── throughput section (divider + gen + prefill) ───────────────────────
 	var throughputLines []string
 	_, p50, p95, n := computeTPSStats(s.tpsHistory)
-	hasTPS := n > 0 || s.liveTPS > 0 || s.livePrefillTPS > 0
+	hasTPS := n > 0 || s.liveTPS > 0 || s.livePrefillTPS > 0 || s.promptProgress > 0
 
-	if hasTPS || s.promptProgress > 0 {
+	if hasTPS {
 		divider := dim.Render("  " + strings.Repeat("─", max(s.width-6, 20)))
 		throughputLines = append(throughputLines, divider)
 
@@ -389,9 +395,6 @@ func (s ServerModel) View() string {
 		if s.liveActive > 0 {
 			genSegs = append(genSegs, lipgloss.NewStyle().Foreground(t.Success).Render(fmt.Sprintf("● %d active", s.liveActive)))
 		}
-		if s.promptProgress > 0 {
-			genSegs = append(genSegs, hi.Render(fmt.Sprintf("%d%% prompt", s.promptProgress)))
-		}
 		if s.liveDeferred > 0 {
 			genSegs = append(genSegs, dim.Render(fmt.Sprintf("%d queued", s.liveDeferred)))
 		}
@@ -404,6 +407,9 @@ func (s ServerModel) View() string {
 		var prefillSegs []string
 		if s.livePrefillTPS > 0 {
 			prefillSegs = append(prefillSegs, val.Render(fmt.Sprintf("%.0f t/s", s.livePrefillTPS)))
+		}
+		if s.promptProgress > 0 {
+			prefillSegs = append(prefillSegs, hi.Render(fmt.Sprintf("%d%% prompt", s.promptProgress)))
 		}
 		var lifetimeSegs []string
 		if s.liveTotalGen > 0 {


### PR DESCRIPTION
This PR intercepts the "prompt processing progress" messages in the llama-server log and displays the percentage as a new stat:
<img width="1265" height="298" alt="image" src="https://github.com/user-attachments/assets/523ac8d6-96f3-4ff7-9e27-31134bbfb699" />
