### PR TITLE
Command line parameter to auto-launch a profile

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -414,7 +414,7 @@ SELECT id, model_id, name, port, host, context_size, ngl,
        batch_size, ubatch_size, cache_type_k, cache_type_v,
        flash_attn, jinja, temperature, reasoning_budget, top_p, top_k,
        no_kv_offload, use_mmproj, extra_flags
-FROM profiles WHERE model_id = ? ORDER BY name`, modelID)
+FROM profiles WHERE model_id = ? OR ? = 0 ORDER BY name`, modelID, modelID)
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -67,8 +67,12 @@ func main() {
 		}
 	}
 
-	app := tui.NewApp(database, serverBin, scanDirs, entries, 80, 24, *profileName)
-	p := tea.NewProgram(&app, tea.WithAltScreen(), tea.WithMouseCellMotion())
+	app, err := tui.NewApp(database, serverBin, scanDirs, entries, 80, 24, *profileName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+	p := tea.NewProgram(app, tea.WithAltScreen(), tea.WithMouseCellMotion())
 
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 
 func main() {
 	showVersion := flag.Bool("version", false, "print version")
+	profileName := flag.String("p", "", "profile name to launch")
 	flag.Parse()
 
 	if *showVersion {
@@ -66,7 +67,7 @@ func main() {
 		}
 	}
 
-	app := tui.NewApp(database, serverBin, scanDirs, entries, 80, 24)
+	app := tui.NewApp(database, serverBin, scanDirs, entries, 80, 24, *profileName)
 	p := tea.NewProgram(&app, tea.WithAltScreen(), tea.WithMouseCellMotion())
 
 	sigChan := make(chan os.Signal, 1)

--- a/tui/app.go
+++ b/tui/app.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/charmbracelet/bubbles/help"
@@ -71,7 +72,7 @@ type AppModel struct {
 	selectedProfile model.Profile
 }
 
-func NewApp(database *db.DB, serverBin string, scanDirs []string, entries []model.ModelEntry, w, h int, launchProfileName string) AppModel {
+func NewApp(database *db.DB, serverBin string, scanDirs []string, entries []model.ModelEntry, w, h int, launchProfileName string) (*AppModel, error) {
 	recent, _ := database.ListRecents(2)
 
 	dbBin, err := database.GetDefaultExecutorPath()
@@ -83,37 +84,41 @@ func NewApp(database *db.DB, serverBin string, scanDirs []string, entries []mode
 	var selProfile model.Profile
 	if launchProfileName != "" {
 		profiles, err := database.ListProfiles(0)
-		if err == nil {
-			for i := range profiles {
-				if profiles[i].Name == launchProfileName {
-					models, _ := database.ListModels()
-					for j := range models {
-						if models[j].ID == profiles[i].ModelID {
-							selProfile = profiles[i]
-							selModel = models[j]
-							break
-						}
-					}
-					break
+		if err != nil {
+			return nil, fmt.Errorf("list profiles: %w", err)
+		}
+		for i := range profiles {
+			if profiles[i].Name == launchProfileName {
+				models, err := database.ListModels()
+				if err != nil {
+					return nil, fmt.Errorf("list models: %w", err)
 				}
+				for j := range models {
+					if models[j].ID == profiles[i].ModelID {
+						selProfile = profiles[i]
+						selModel = models[j]
+						break
+					}
+				}
+				break
 			}
 		}
 	}
 
-	return AppModel{
-		database:      database,
-		serverBin:     serverBin,
-		scanDirs:      scanDirs,
-		width:         w,
-		height:        h,
-		help:          help.New(),
-		home:          NewHomeModel(recent, scanDirs, serverBin, w, h),
-		modelList:     NewModelListModel(entries, w, h),
+	return &AppModel{
+		database:        database,
+		serverBin:       serverBin,
+		scanDirs:        scanDirs,
+		width:           w,
+		height:          h,
+		help:            help.New(),
+		home:            NewHomeModel(recent, scanDirs, serverBin, w, h),
+		modelList:       NewModelListModel(entries, w, h),
 		executor:        NewExecutorModel(database, serverBin, w, h),
 		themeSelector:   NewThemeSelectorModel(w, h),
 		selectedModel:   selModel,
 		selectedProfile: selProfile,
-	}
+	}, nil
 }
 
 func (a *AppModel) Init() tea.Cmd {

--- a/tui/app.go
+++ b/tui/app.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/dipankardas011/infai/db"
+	"github.com/dipankardas011/infai/launcher"
 	"github.com/dipankardas011/infai/model"
 	"github.com/dipankardas011/infai/scanner"
 )
@@ -70,12 +71,33 @@ type AppModel struct {
 	selectedProfile model.Profile
 }
 
-func NewApp(database *db.DB, serverBin string, scanDirs []string, entries []model.ModelEntry, w, h int) AppModel {
+func NewApp(database *db.DB, serverBin string, scanDirs []string, entries []model.ModelEntry, w, h int, launchProfileName string) AppModel {
 	recent, _ := database.ListRecents(2)
 
 	dbBin, err := database.GetDefaultExecutorPath()
 	if err == nil && dbBin != "" {
 		serverBin = dbBin
+	}
+
+	var selModel model.ModelEntry
+	var selProfile model.Profile
+	if launchProfileName != "" {
+		profiles, err := database.ListProfiles(0)
+		if err == nil {
+			for i := range profiles {
+				if profiles[i].Name == launchProfileName {
+					models, _ := database.ListModels()
+					for j := range models {
+						if models[j].ID == profiles[i].ModelID {
+							selProfile = profiles[i]
+							selModel = models[j]
+							break
+						}
+					}
+					break
+				}
+			}
+		}
 	}
 
 	return AppModel{
@@ -87,12 +109,35 @@ func NewApp(database *db.DB, serverBin string, scanDirs []string, entries []mode
 		help:          help.New(),
 		home:          NewHomeModel(recent, scanDirs, serverBin, w, h),
 		modelList:     NewModelListModel(entries, w, h),
-		executor:      NewExecutorModel(database, serverBin, w, h),
-		themeSelector: NewThemeSelectorModel(w, h),
+		executor:        NewExecutorModel(database, serverBin, w, h),
+		themeSelector:   NewThemeSelectorModel(w, h),
+		selectedModel:   selModel,
+		selectedProfile: selProfile,
 	}
 }
 
-func (a *AppModel) Init() tea.Cmd { return toastTick() }
+func (a *AppModel) Init() tea.Cmd {
+	if a.selectedProfile.Name != "" {
+		args := launcher.BuildArgs(a.serverBin, a.selectedModel, a.selectedProfile)
+		sm, cmd, err := NewServerModel(
+			args,
+			a.selectedProfile.Name,
+			a.selectedModel.DisplayName,
+			a.selectedModel.Type,
+			a.selectedProfile.ContextSize,
+			a.selectedProfile.Host,
+			a.selectedProfile.Port,
+			a.width,
+			a.height,
+		)
+		if err == nil {
+			a.server = sm
+			a.screen = screenServerRunning
+		}
+		return cmd
+	}
+	return toastTick()
+}
 
 func (a *AppModel) setErr(msg string) {
 	a.errMsg = msg

--- a/tui/app.go
+++ b/tui/app.go
@@ -103,6 +103,9 @@ func NewApp(database *db.DB, serverBin string, scanDirs []string, entries []mode
 				break
 			}
 		}
+		if selProfile.Name == "" {
+			return nil, fmt.Errorf("profile %q not found", launchProfileName)
+		}
 	}
 
 	return &AppModel{


### PR DESCRIPTION
This PR adds a `-p <profilename>` command line parameter that skips TUI profile selection and launches directly the specified profile.
I find this useful to launch `infai` inside `screen` with a profile already running at machine startup.