### PR TITLE
feat(profile): Implement profile browsing functionality

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -408,6 +408,39 @@ type RecentEntry struct {
 	Profile model.Profile
 }
 
+type ProfileEntry struct {
+	Model   model.ModelEntry
+	Profile model.Profile
+}
+
+func (d *DB) ListAllProfiles() ([]ProfileEntry, error) {
+	rows, err := d.conn.Query(`
+SELECT m.id, m.scan_dir, m.gguf_path, m.mmproj_path, m.display_name, m.type,
+       p.id, p.model_id, p.name, p.port, p.host, p.context_size
+FROM profiles p
+JOIN models m ON p.model_id = m.id
+ORDER BY lower(m.display_name), lower(p.name)`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []ProfileEntry
+	for rows.Next() {
+		var m model.ModelEntry
+		var p model.Profile
+		err := rows.Scan(
+			&m.ID, &m.ScanDir, &m.GGUFPath, &m.MmprojPath, &m.DisplayName, &m.Type,
+			&p.ID, &p.ModelID, &p.Name, &p.Port, &p.Host, &p.ContextSize,
+		)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, ProfileEntry{Model: m, Profile: p})
+	}
+	return out, rows.Err()
+}
+
 func (d *DB) ListProfiles(modelID int64) ([]model.Profile, error) {
 	rows, err := d.conn.Query(`
 SELECT id, model_id, name, port, host, context_size, ngl,
@@ -428,6 +461,27 @@ FROM profiles WHERE model_id = ? ORDER BY name`, modelID)
 		out = append(out, p)
 	}
 	return out, rows.Err()
+}
+
+func (d *DB) GetProfile(id int64) (model.Profile, error) {
+	rows, err := d.conn.Query(`
+SELECT id, model_id, name, port, host, context_size, ngl,
+       batch_size, ubatch_size, cache_type_k, cache_type_v,
+       flash_attn, jinja, temperature, reasoning_budget, top_p, top_k,
+       no_kv_offload, use_mmproj, extra_flags
+FROM profiles WHERE id = ?`, id)
+	if err != nil {
+		return model.Profile{}, err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return model.Profile{}, sql.ErrNoRows
+	}
+	p, err := scanProfile(rows)
+	if err != nil {
+		return model.Profile{}, err
+	}
+	return p, rows.Err()
 }
 
 func (d *DB) UpsertProfile(p *model.Profile) error {

--- a/tui/app.go
+++ b/tui/app.go
@@ -1,6 +1,10 @@
 package tui
 
 import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/charmbracelet/bubbles/help"
@@ -24,6 +28,7 @@ type screenKind int
 const (
 	screenHome screenKind = iota
 	screenModelList
+	screenProfileBrowser
 	screenProfileList
 	screenProfileEdit
 	screenConfirm
@@ -33,8 +38,18 @@ const (
 	screenThemeSelector
 )
 
+type modelListPurpose int
+
+const (
+	modelListBrowse modelListPurpose = iota
+	modelListPickForProfile
+)
+
 // Cross-screen transition messages.
-type scanDoneMsg struct{ entries []model.ModelEntry }
+type scanDoneMsg struct {
+	entries []model.ModelEntry
+	err     error
+}
 type saveProfileMsg struct{ profile model.Profile }
 type deleteProfileMsg struct{ id int64 }
 type syncDoneMsg struct {
@@ -56,39 +71,57 @@ type AppModel struct {
 	help         help.Model
 	showFullHelp bool
 
-	modelList     ModelListModel
-	profileList   ProfileListModel
-	profileEdit   ProfileEditModel
-	confirm       ConfirmModel
-	server        ServerModel
-	explore       ExploreModel
-	executor      ExecutorModel
-	home          HomeModel
-	themeSelector ThemeSelectorModel
+	modelList      ModelListModel
+	profileBrowser ProfileBrowserModel
+	profileList    ProfileListModel
+	profileEdit    ProfileEditModel
+	confirm        ConfirmModel
+	server         ServerModel
+	explore        ExploreModel
+	executor       ExecutorModel
+	home           HomeModel
+	themeSelector  ThemeSelectorModel
 
-	selectedModel   model.ModelEntry
-	selectedProfile model.Profile
+	selectedModel     model.ModelEntry
+	selectedProfile   model.Profile
+	modelListPurpose  modelListPurpose
+	profileEditReturn screenKind
+	confirmReturn     screenKind
 }
 
 func NewApp(database *db.DB, serverBin string, scanDirs []string, entries []model.ModelEntry, w, h int) AppModel {
-	recent, _ := database.ListRecents(2)
+	var startupErrs []string
+
+	recent, err := database.ListRecents(2)
+	if err != nil {
+		startupErrs = append(startupErrs, fmt.Sprintf("failed to load recents: %v", err))
+	}
 
 	dbBin, err := database.GetDefaultExecutorPath()
 	if err == nil && dbBin != "" {
 		serverBin = dbBin
+	} else if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		startupErrs = append(startupErrs, fmt.Sprintf("failed to load executor: %v", err))
+	}
+
+	profiles, err := database.ListAllProfiles()
+	if err != nil {
+		startupErrs = append(startupErrs, fmt.Sprintf("failed to load profiles: %v", err))
 	}
 
 	return AppModel{
-		database:      database,
-		serverBin:     serverBin,
-		scanDirs:      scanDirs,
-		width:         w,
-		height:        h,
-		help:          help.New(),
-		home:          NewHomeModel(recent, scanDirs, serverBin, w, h),
-		modelList:     NewModelListModel(entries, w, h),
-		executor:      NewExecutorModel(database, serverBin, w, h),
-		themeSelector: NewThemeSelectorModel(w, h),
+		database:       database,
+		serverBin:      serverBin,
+		scanDirs:       scanDirs,
+		width:          w,
+		height:         h,
+		errMsg:         strings.Join(startupErrs, "; "),
+		help:           help.New(),
+		home:           NewHomeModel(recent, scanDirs, serverBin, w, h),
+		modelList:      NewModelListModel(entries, w, h),
+		profileBrowser: NewProfileBrowserModel(profiles, w, h),
+		executor:       NewExecutorModel(database, serverBin, w, h),
+		themeSelector:  NewThemeSelectorModel(w, h),
 	}
 }
 
@@ -100,8 +133,21 @@ func (a *AppModel) setErr(msg string) {
 }
 
 func (a *AppModel) refreshHome() {
-	recent, _ := a.database.ListRecents(2)
+	recent, err := a.database.ListRecents(2)
+	if err != nil {
+		a.setErr(err.Error())
+		return
+	}
 	a.home = NewHomeModel(recent, a.scanDirs, a.serverBin, a.width, a.height)
+}
+
+func (a *AppModel) refreshProfileBrowser() {
+	profiles, err := a.database.ListAllProfiles()
+	if err != nil {
+		a.setErr(err.Error())
+		return
+	}
+	a.profileBrowser = a.profileBrowser.SetEntries(profiles).SetSize(a.width, a.height)
 }
 
 func (a *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -122,6 +168,7 @@ func (a *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.help.Width = msg.Width
 		a.home = a.home.SetSize(a.width, a.height)
 		a.modelList = a.modelList.SetSize(a.width, a.height)
+		a.profileBrowser = a.profileBrowser.SetSize(a.width, a.height)
 		a.profileList = a.profileList.SetSize(a.width, a.height)
 		a.profileEdit = a.profileEdit.SetSize(a.width, a.height)
 		a.confirm = a.confirm.SetSize(a.width, a.height)
@@ -132,12 +179,17 @@ func (a *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, nil
 
 	case scanDoneMsg:
+		if msg.err != nil {
+			a.setErr(msg.err.Error())
+			return a, nil
+		}
 		for i := range msg.entries {
 			if err := a.database.UpsertModel(&msg.entries[i]); err != nil {
 				a.setErr(err.Error())
 			}
 		}
 		a.modelList = a.modelList.SetEntries(msg.entries)
+		a.refreshProfileBrowser()
 		a.refreshHome()
 		return a, nil
 
@@ -147,9 +199,19 @@ func (a *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.setErr(err.Error())
 			return a, nil
 		}
-		profiles, _ := a.database.ListProfiles(a.selectedModel.ID)
-		a.profileList = a.profileList.SetProfiles(profiles)
-		a.screen = screenProfileList
+		switch a.profileEditReturn {
+		case screenProfileBrowser:
+			a.refreshProfileBrowser()
+			a.screen = screenProfileBrowser
+		default:
+			profiles, err := a.database.ListProfiles(a.selectedModel.ID)
+			if err != nil {
+				a.setErr(err.Error())
+				return a, nil
+			}
+			a.profileList = a.profileList.SetProfiles(profiles)
+			a.screen = screenProfileList
+		}
 		return a, nil
 
 	case deleteProfileMsg:
@@ -157,7 +219,15 @@ func (a *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.setErr(err.Error())
 			return a, nil
 		}
-		profiles, _ := a.database.ListProfiles(a.selectedModel.ID)
+		if a.screen == screenProfileBrowser {
+			a.refreshProfileBrowser()
+			return a, nil
+		}
+		profiles, err := a.database.ListProfiles(a.selectedModel.ID)
+		if err != nil {
+			a.setErr(err.Error())
+			return a, nil
+		}
 		a.profileList = a.profileList.SetProfiles(profiles)
 		return a, nil
 
@@ -226,6 +296,8 @@ func (a *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a.updateHome(msg)
 		case screenModelList:
 			return a.updateModelList(msg)
+		case screenProfileBrowser:
+			return a.updateProfileBrowser(msg)
 		case screenProfileList:
 			return a.updateProfileList(msg)
 		case screenProfileEdit:
@@ -256,6 +328,10 @@ func (a *AppModel) handleNonKeyMsg(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case screenModelList:
 		var cmd tea.Cmd
 		a.modelList, cmd = a.modelList.Update(msg)
+		return a, cmd
+	case screenProfileBrowser:
+		var cmd tea.Cmd
+		a.profileBrowser, cmd = a.profileBrowser.Update(msg)
 		return a, cmd
 	case screenProfileList:
 		var cmd tea.Cmd
@@ -288,7 +364,8 @@ func (a *AppModel) handleNonKeyMsg(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (a *AppModel) updateHome(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "a":
-		a.screen = screenModelList
+		a.refreshProfileBrowser()
+		a.screen = screenProfileBrowser
 		return a, nil
 	case "f":
 		a.explore.Close()
@@ -308,6 +385,7 @@ func (a *AppModel) updateHome(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			a.selectedModel = entry.Model
 			a.selectedProfile = entry.Profile
 			a.confirm = NewConfirmModel(a.serverBin, entry.Model, entry.Profile, a.width, a.height)
+			a.confirmReturn = screenHome
 			a.screen = screenConfirm
 			a.errMsg = ""
 			return a, nil
@@ -357,6 +435,11 @@ func (a *AppModel) updateModelList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "esc":
 		if !a.modelList.IsFiltering() {
+			if a.modelListPurpose == modelListPickForProfile {
+				a.refreshProfileBrowser()
+				a.screen = screenProfileBrowser
+				return a, nil
+			}
 			a.refreshHome()
 			a.screen = screenHome
 			return a, nil
@@ -364,7 +447,18 @@ func (a *AppModel) updateModelList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "enter":
 		if entry, ok := a.modelList.Selected(); ok {
 			a.selectedModel = entry
-			profiles, _ := a.database.ListProfiles(entry.ID)
+			if a.modelListPurpose == modelListPickForProfile {
+				a.profileEdit = NewProfileEditModel(entry, nil, a.width, a.height)
+				a.profileEditReturn = screenProfileBrowser
+				a.screen = screenProfileEdit
+				a.errMsg = ""
+				return a, nil
+			}
+			profiles, err := a.database.ListProfiles(entry.ID)
+			if err != nil {
+				a.setErr(err.Error())
+				return a, nil
+			}
 			a.profileList = NewProfileListModel(entry, profiles, a.width, a.height)
 			a.screen = screenProfileList
 			a.errMsg = ""
@@ -372,12 +466,109 @@ func (a *AppModel) updateModelList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "r":
 		return a, func() tea.Msg {
-			entries, _ := scanner.Scan(a.scanDirs)
-			return scanDoneMsg{entries: entries}
+			entries, err := scanner.Scan(a.scanDirs)
+			return scanDoneMsg{entries: entries, err: err}
 		}
 	}
 	var cmd tea.Cmd
 	a.modelList, cmd = a.modelList.Update(msg)
+	return a, cmd
+}
+
+func (a *AppModel) openProfileModelPicker() (tea.Model, tea.Cmd) {
+	entries, err := a.database.ListModels()
+	if err != nil {
+		a.setErr(err.Error())
+		return a, nil
+	}
+	if len(entries) == 0 {
+		a.setErr("no models found - press [f] on home to add scan folders")
+		return a, nil
+	}
+	a.modelList = NewModelListModel(entries, a.width, a.height).SetTitle("Choose model for new profile")
+	a.modelListPurpose = modelListPickForProfile
+	a.screen = screenModelList
+	return a, nil
+}
+
+func (a *AppModel) updateProfileBrowser(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if a.profileBrowser.IsFiltering() {
+		if msg.String() == "esc" {
+			var cmd tea.Cmd
+			a.profileBrowser, cmd = a.profileBrowser.Update(msg)
+			return a, cmd
+		}
+		var cmd tea.Cmd
+		a.profileBrowser, cmd = a.profileBrowser.Update(msg)
+		return a, cmd
+	}
+
+	if a.profileBrowser.deleteConfirm {
+		switch msg.String() {
+		case "y":
+			id := a.profileBrowser.deleteID
+			a.profileBrowser.deleteConfirm = false
+			a.profileBrowser.deleteID = 0
+			return a, func() tea.Msg { return deleteProfileMsg{id: id} }
+		case "n", "esc":
+			a.profileBrowser.deleteConfirm = false
+			a.profileBrowser.deleteID = 0
+			return a, nil
+		default:
+			return a, nil
+		}
+	}
+
+	switch msg.String() {
+	case "esc", "backspace":
+		a.refreshHome()
+		a.screen = screenHome
+		a.errMsg = ""
+		return a, nil
+	case "n":
+		return a.openProfileModelPicker()
+	case "enter":
+		entry, ok := a.profileBrowser.Selected()
+		if !ok {
+			break
+		}
+		profile, err := a.database.GetProfile(entry.Profile.ID)
+		if err != nil {
+			a.setErr(err.Error())
+			return a, nil
+		}
+		a.selectedModel = entry.Model
+		a.selectedProfile = profile
+		a.confirm = NewConfirmModel(a.serverBin, entry.Model, profile, a.width, a.height)
+		a.confirmReturn = screenProfileBrowser
+		a.screen = screenConfirm
+		a.errMsg = ""
+		return a, nil
+	case "e":
+		if entry, ok := a.profileBrowser.SelectedProfile(); ok {
+			profile, err := a.database.GetProfile(entry.Profile.ID)
+			if err != nil {
+				a.setErr(err.Error())
+				return a, nil
+			}
+			a.selectedModel = entry.Model
+			a.profileEdit = NewProfileEditModel(entry.Model, &profile, a.width, a.height)
+			a.profileEditReturn = screenProfileBrowser
+			a.screen = screenProfileEdit
+			return a, nil
+		}
+	case "d":
+		if a.profileBrowser.deleteConfirm {
+			break
+		}
+		if entry, ok := a.profileBrowser.SelectedProfile(); ok {
+			a.profileBrowser.deleteConfirm = true
+			a.profileBrowser.deleteID = entry.Profile.ID
+			return a, nil
+		}
+	}
+	var cmd tea.Cmd
+	a.profileBrowser, cmd = a.profileBrowser.Update(msg)
 	return a, cmd
 }
 
@@ -398,11 +589,13 @@ func (a *AppModel) updateProfileList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		if isNew {
 			a.profileEdit = NewProfileEditModel(a.selectedModel, nil, a.width, a.height)
+			a.profileEditReturn = screenProfileList
 			a.screen = screenProfileEdit
 			return a, nil
 		}
 		a.selectedProfile = profile
 		a.confirm = NewConfirmModel(a.serverBin, a.selectedModel, profile, a.width, a.height)
+		a.confirmReturn = screenProfileList
 		a.screen = screenConfirm
 		a.errMsg = ""
 		return a, nil
@@ -410,6 +603,7 @@ func (a *AppModel) updateProfileList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "e":
 		if profile, ok := a.profileList.SelectedProfile(); ok {
 			a.profileEdit = NewProfileEditModel(a.selectedModel, &profile, a.width, a.height)
+			a.profileEditReturn = screenProfileList
 			a.screen = screenProfileEdit
 			return a, nil
 		}
@@ -447,7 +641,10 @@ func (a *AppModel) updateProfileList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (a *AppModel) updateProfileEdit(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "esc":
-		a.screen = screenProfileList
+		a.screen = a.profileEditReturn
+		if a.screen == screenHome {
+			a.screen = screenProfileList
+		}
 		a.profileEdit.errMsg = ""
 		return a, nil
 	case "ctrl+s":
@@ -466,7 +663,10 @@ func (a *AppModel) updateProfileEdit(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (a *AppModel) updateConfirm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "esc":
-		a.screen = screenHome
+		a.screen = a.confirmReturn
+		if a.screen == screenHome {
+			a.refreshHome()
+		}
 		return a, nil
 	case "enter":
 		if a.confirm.command == "" {
@@ -548,7 +748,11 @@ func (a *AppModel) updateExplore(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "esc":
 		a.scanDirs = a.explore.Dirs()
 		a.refreshHome()
-		entries, _ := a.database.ListModels()
+		entries, err := a.database.ListModels()
+		if err != nil {
+			a.setErr(err.Error())
+			return a, nil
+		}
 		a.modelList = a.modelList.SetEntries(entries)
 		a.screen = screenHome
 		return a, nil
@@ -583,6 +787,8 @@ func (a *AppModel) View() string {
 		body = a.home.SetSize(a.width, innerH).View()
 	case screenModelList:
 		body = a.modelList.SetSize(a.width, innerH).View()
+	case screenProfileBrowser:
+		body = a.profileBrowser.SetSize(a.width, innerH).View()
 	case screenProfileList:
 		body = a.profileList.SetSize(a.width, innerH).View()
 	case screenProfileEdit:
@@ -615,6 +821,8 @@ func (a *AppModel) helpView() string {
 		helpContent = a.help.View(keys.Home)
 	case screenModelList:
 		helpContent = a.help.View(keys.ModelList)
+	case screenProfileBrowser:
+		helpContent = a.help.View(keys.ProfileBrowser)
 	case screenProfileList:
 		helpContent = a.help.View(keys.ProfileList)
 	case screenConfirm:

--- a/tui/home.go
+++ b/tui/home.go
@@ -81,10 +81,10 @@ func (m HomeModel) View() string {
 		Render(strings.Repeat("─", hrWidth))
 
 	// Recents Section
-	recentTitle := styleKey.Render("Recents") + styleMuted.Render(" [a]ll")
+	recentTitle := styleKey.Render("Recent launches")
 	var recentItems []string
 	if len(m.recentModels) == 0 {
-		recentItems = append(recentItems, styleMuted.Render("  No recents found. Press [a] to see all or [f] to add folders."))
+		recentItems = append(recentItems, styleMuted.Render("  No recents found. Press [a] to create a profile or [f] to add folders."))
 	} else {
 		for i, entry := range m.recentModels {
 			prefix := "  "

--- a/tui/keys.go
+++ b/tui/keys.go
@@ -78,6 +78,23 @@ func (k profileListKeyMap) ShortHelp() []key.Binding {
 }
 func (k profileListKeyMap) FullHelp() [][]key.Binding { return [][]key.Binding{k.ShortHelp()} }
 
+type profileBrowserKeyMap struct {
+	Enter  key.Binding
+	New    key.Binding
+	Edit   key.Binding
+	Delete key.Binding
+	Filter key.Binding
+	Back   key.Binding
+	Help   key.Binding
+}
+
+func (k profileBrowserKeyMap) ShortHelp() []key.Binding {
+	return []key.Binding{k.Enter, k.New, k.Edit, k.Delete, k.Filter, k.Back, k.Help}
+}
+func (k profileBrowserKeyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{{k.Enter, k.New, k.Edit, k.Delete}, {k.Filter, k.Back, k.Help}}
+}
+
 type confirmKeyMap struct {
 	Launch key.Binding
 	Back   key.Binding
@@ -115,18 +132,19 @@ func (k executorKeyMap) ShortHelp() []key.Binding {
 func (k executorKeyMap) FullHelp() [][]key.Binding { return [][]key.Binding{k.ShortHelp()} }
 
 var keys = struct {
-	Home        homeKeyMap
-	ModelList   modelListKeyMap
-	Explore     exploreKeyMap
-	FileBrowser fileBrowserKeyMap
-	ProfileList profileListKeyMap
-	Confirm     confirmKeyMap
-	Server      serverKeyMap
-	Executor    executorKeyMap
+	Home           homeKeyMap
+	ModelList      modelListKeyMap
+	Explore        exploreKeyMap
+	FileBrowser    fileBrowserKeyMap
+	ProfileList    profileListKeyMap
+	ProfileBrowser profileBrowserKeyMap
+	Confirm        confirmKeyMap
+	Server         serverKeyMap
+	Executor       executorKeyMap
 }{
 	Home: homeKeyMap{
 		Enter:     key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
-		All:       key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "all models")),
+		All:       key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "profiles")),
 		Folders:   key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "folders")),
 		Configure: key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "executor")),
 		Theme:     key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "theme")),
@@ -161,6 +179,15 @@ var keys = struct {
 		Edit:   key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "edit")),
 		Delete: key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "delete")),
 		Back:   key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
+		Help:   key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
+	},
+	ProfileBrowser: profileBrowserKeyMap{
+		Enter:  key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "launch")),
+		New:    key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "new")),
+		Edit:   key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "edit")),
+		Delete: key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "delete")),
+		Filter: key.NewBinding(key.WithKeys("/"), key.WithHelp("/", "filter")),
+		Back:   key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "home")),
 		Help:   key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
 	},
 	Confirm: confirmKeyMap{

--- a/tui/modellist.go
+++ b/tui/modellist.go
@@ -13,8 +13,7 @@ import (
 	"github.com/dipankardas011/infai/model"
 )
 
-const logoASCII = `
-██╗███╗   ██╗███████╗ █████╗ ██╗
+const logoASCII = `██╗███╗   ██╗███████╗ █████╗ ██╗
 ██║████╗  ██║██╔════╝██╔══██╗██║
 ██║██╔██╗ ██║█████╗  ███████║██║
 ██║██║╚██╗██║██╔══╝  ██╔══██║██║
@@ -75,7 +74,7 @@ func NewModelListModel(entries []model.ModelEntry, w, h int) ModelListModel {
 		items[i] = modelItem{entry: e}
 	}
 	l := list.New(items, modelDelegate{}, w, h-4)
-	l.Title = "infai"
+	l.Title = "Models"
 	l.Styles.Title = styleTitle
 	l.SetShowStatusBar(false)
 	l.SetFilteringEnabled(true)
@@ -100,6 +99,11 @@ func (m ModelListModel) SetEntries(entries []model.ModelEntry) ModelListModel {
 		items[i] = modelItem{entry: e}
 	}
 	m.list.SetItems(items)
+	return m
+}
+
+func (m ModelListModel) SetTitle(title string) ModelListModel {
+	m.list.Title = title
 	return m
 }
 

--- a/tui/profilebrowser.go
+++ b/tui/profilebrowser.go
@@ -1,0 +1,179 @@
+package tui
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/dipankardas011/infai/db"
+)
+
+// ProfileBrowserModel shows every saved profile across every discovered model.
+// It intentionally mirrors ModelListModel's bubbles/list implementation.
+type ProfileBrowserModel struct {
+	list          list.Model
+	entries       []db.ProfileEntry
+	deleteConfirm bool
+	deleteID      int64
+	statusMsg     string
+	width         int
+	height        int
+	initialized   bool
+}
+
+type profileBrowserItem struct {
+	entry db.ProfileEntry
+}
+
+func (p profileBrowserItem) FilterValue() string {
+	parts := []string{
+		p.entry.Profile.Name,
+		p.entry.Model.DisplayName,
+		p.entry.Model.Type,
+		p.entry.Model.ScanDir,
+		p.entry.Model.GGUFPath,
+	}
+	return strings.Join(parts, " ")
+}
+
+func (p profileBrowserItem) Title() string {
+	return p.entry.Profile.Name
+}
+
+func (p profileBrowserItem) Description() string {
+	profile := p.entry.Profile
+	return strings.TrimSpace(fmt.Sprintf("ctx:%s port:%d host:%s %s", fmtInt(profile.ContextSize), profile.Port, profile.Host, profileLocation(p.entry)))
+}
+
+type profileBrowserDelegate struct{}
+
+func (d profileBrowserDelegate) Height() int                             { return 3 }
+func (d profileBrowserDelegate) Spacing() int                            { return 1 }
+func (d profileBrowserDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
+
+func (d profileBrowserDelegate) Render(w io.Writer, m list.Model, index int, item list.Item) {
+	i, ok := item.(profileBrowserItem)
+	if !ok {
+		return
+	}
+	selected := index == m.Index()
+
+	p := i.entry.Profile
+	title := lipgloss.NewStyle().Foreground(colorText).Render("  " + p.Name)
+	if selected {
+		title = styleSelected.Render("▶ " + p.Name)
+	}
+
+	profileLine := styleMuted.Render(fmt.Sprintf("ctx:%s  port:%d  host:%s", fmtInt(p.ContextSize), p.Port, p.Host))
+	locationLine := styleMuted.Render(profileLocation(i.entry))
+	fmt.Fprintf(w, "%s\n  %s\n  %s", title, profileLine, locationLine)
+}
+
+func NewProfileBrowserModel(entries []db.ProfileEntry, w, h int) ProfileBrowserModel {
+	items := buildProfileBrowserItems(entries)
+	listW := 76
+	if w < listW+4 {
+		listW = w - 4
+	}
+	if listW < 20 {
+		listW = 20
+	}
+	l := list.New(items, profileBrowserDelegate{}, listW, h-8)
+	l.Title = "Profiles"
+	l.Styles.Title = styleTitle
+	l.SetShowStatusBar(true)
+	l.SetFilteringEnabled(true)
+	l.SetShowHelp(false)
+	l.StatusMessageLifetime = 0
+	return ProfileBrowserModel{list: l, entries: entries, width: w, height: h, initialized: true}
+}
+
+func buildProfileBrowserItems(entries []db.ProfileEntry) []list.Item {
+	items := make([]list.Item, 0, len(entries))
+	for _, entry := range entries {
+		items = append(items, profileBrowserItem{entry: entry})
+	}
+	return items
+}
+
+func profileLocation(entry db.ProfileEntry) string {
+	model := entry.Model
+	parts := []string{model.DisplayName}
+	if model.ScanDir != "" {
+		parts = append(parts, model.ScanDir)
+	} else if model.GGUFPath != "" {
+		parts = append(parts, model.GGUFPath)
+	}
+	return strings.Join(parts, " · ")
+}
+
+func (m ProfileBrowserModel) SetSize(w, h int) ProfileBrowserModel {
+	if !m.initialized {
+		return m
+	}
+	m.width, m.height = w, h
+	listW := 76
+	if w < listW+4 {
+		listW = w - 4
+	}
+	if listW < 20 {
+		listW = 20
+	}
+	m.list.SetSize(listW, h-8)
+	return m
+}
+
+func (m ProfileBrowserModel) SetEntries(entries []db.ProfileEntry) ProfileBrowserModel {
+	m.entries = entries
+	m.statusMsg = ""
+	m.list.SetItems(buildProfileBrowserItems(entries))
+	return m
+}
+
+func (m ProfileBrowserModel) Update(msg tea.Msg) (ProfileBrowserModel, tea.Cmd) {
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+func (m ProfileBrowserModel) View() string {
+	t := ActiveTheme
+	status := ""
+	if m.deleteConfirm {
+		status = styleError.Render("Delete this profile? (y/n)")
+	} else if m.statusMsg != "" {
+		status = styleMuted.Render(m.statusMsg)
+	}
+
+	content := lipgloss.JoinVertical(lipgloss.Left,
+		m.list.View(),
+		status,
+	)
+
+	boxStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(t.Muted).
+		Padding(1, 2)
+
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, boxStyle.Render(content))
+}
+
+func (m ProfileBrowserModel) Selected() (db.ProfileEntry, bool) {
+	item, ok := m.list.SelectedItem().(profileBrowserItem)
+	if !ok {
+		return db.ProfileEntry{}, false
+	}
+	return item.entry, true
+}
+
+func (m ProfileBrowserModel) SelectedProfile() (db.ProfileEntry, bool) {
+	return m.Selected()
+}
+
+func (m ProfileBrowserModel) IsFiltering() bool {
+	return strings.Contains(m.list.FilterState().String(), "filtering")
+}


### PR DESCRIPTION
This commit introduces the capability to view, select, and edit specific profiles within the application.

**Database changes:**
*   Added the `ProfileEntry` struct to couple `model.ModelEntry` and `model.Profile`.
*   Implemented `ListAllProfiles()` to fetch combined model and profile data.
*   Added `GetProfile(id int64)` to retrieve detailed profile information by ID.

**UI changes:**
*   Introduced `ProfileBrowserModel` to manage the list view of profiles, mirroring existing list functionality.
*   Integrated the profile browser into the main application flow, supporting transitions from model selection to profile browsing.
*   Implemented logic for browsing profiles, including selection, viewing details, editing, and deletion confirmation.
*   Updated `AppModel` to hold the new `profileBrowser` state and introduced necessary refresh methods (`refreshProfileBrowser`).
*   Updated message handling to correctly manage errors during profile loading and profile deletion.